### PR TITLE
Change deploy method

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,5 +16,4 @@ jobs:
       - run: echo "${{ secrets.deploy }}" > "$HOME/.ssh/key"
       - run: chmod 600 "$HOME/.ssh/key"
       # Deploy
-      - run: rsync -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" --archive --compress --delete . notabot@nakidai.ru:~/src
-      - run: ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no notabot@nakidai.ru -t "sudo systemctl restart notabot"
+      - run: ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no notabot@nakidai.ru -t "cd src; git pull; sudo systemctl restart notabot"


### PR DESCRIPTION
Because it's needed by #12 (previously it was rsync, but it doesn't look at `.gitignore`, so it also will delete var folder)