### PR TITLE
Add whitespace to getmsg

### DIFF
--- a/extensions/GetMessage/__init__.py
+++ b/extensions/GetMessage/__init__.py
@@ -140,14 +140,14 @@ class Cog(commands.Cog, name="GetMessageCog"):
         try:
             await interaction.followup.send(
                 f"""
-User {message.author.name} sent [message]({message.jump_url}) <t:{timestamp}:D><t:{timestamp}:T>
+User {message.author.name} sent [message]({message.jump_url}) <t:{timestamp}:D> <t:{timestamp}:T>
 {content}""",
                 files=files
             )
         except ValueError:
             await interaction.followup.send(
                 f"""One of the files is too big, I'll not send them
-User {message.author.name} sent [message]({message.jump_url}) <t:{timestamp}:D><t:{timestamp}:T>
+User {message.author.name} sent [message]({message.jump_url}) <t:{timestamp}:D> <t:{timestamp}:T>
 {content}"""
             )
 


### PR DESCRIPTION
Because it looks weird on mobile phones for now:
![image](https://github.com/nakidai/NotABot/assets/89989298/25fc2ae8-09ac-4b74-ba64-e14ef41bfa5a)
