### PR TITLE
Add volume

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,13 @@ services:
     image: notabot
     secrets:
       - notabot-token
+    volumes:
+      - notabot-var:/app/var
 
 secrets:
   notabot-token:
+    external: true
+
+volumes:
+  notabot-var:
     external: true


### PR DESCRIPTION
As `var` should be independent from deploys (for example user created reminder, and bot should remind him even if it has restarted or updated) it needs to be a volume