### PR TITLE
Fix docker deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,9 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v4
       - name: Build
-        run: docker buildx build -t notabot .
-      - name: Export
-        run: docker save notabot | xz > notabot.txz
+        run: docker buildx build -t notabot --output type=tar . | xz > notabot.txz
       - name: Push
-        run: scp -i "$HOME/.ssh/key" notabot.txz notabot@nakidai.ru:notabot.txz
+        run: scp -i "$HOME/.ssh/key" -o StrictHostKeyChecking=no notabot.txz "notabot@nakidai.ru:~/notabot.txz"
       - name: Post Export
         run: rm notabot.txz
       - name: Post Setup SSH


### PR DESCRIPTION
Deploy failed on push which said:
```
Host key verification failed.
lost connection
```
I guess that `-o StrictHostKeyChecking=no` option in scp should fix that

Also before that fail `docker save` failed to export the image (but exited with zero return-code (!)). In build I found that build did not have destination where to save, so it saved image to "build cache". I try to fix exporting from build step directly:
```
docker buildx build -t notabot --output type=tar . | xz > notabot.txz
```