### PR TITLE
Fix speech-to-text

### DIFF
--- a/src/notabot/extensions/SpeechToText/__init__.py
+++ b/src/notabot/extensions/SpeechToText/__init__.py
@@ -25,7 +25,8 @@ class Cog(commands.Cog, name="SpeechToTextCog"):
                 voice = recognizer.record(wav)
 
             try:
-                await message.reply(recognizer.recognize_google(voice))
+                # TODO: move language to config/
+                await message.reply(recognizer.recognize_google(voice, language="ru-RU"))
             except sr.UnknownValueError:
                 await message.reply("Good!")
             except Exception as exc:


### PR DESCRIPTION
Set language manually as without it google can't recognize speech correctly (surprisingly even english speech)

TODO: create config/speechtotext.json with language setting