### PR TITLE
Fix exception in main.py

### DIFF
--- a/src/notabot/main.py
+++ b/src/notabot/main.py
@@ -21,7 +21,7 @@ class Bot(commands.Bot):
             self.config = json.load(f)
 
         if not os.path.exists(self.path("var")):
-            os.mkdir("var", 0o755)
+            os.mkdir(self.path("var"), 0o755)
 
         intents = discord.Intents.default()
         intents.message_content = True


### PR DESCRIPTION
"var" was not enclosed in self.path function, so notabot could produce this exception on start if you set another root with --root cli argument:
FileExistsError: [Errno 17] File exists: 'var'